### PR TITLE
Adds conditional to throw error if selector would start with a number

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,10 @@ export default function wrap(classes, prefix) {
   var className = ""
   var type = typeof classes
 
+  if (classes && type === "number" && prefix === undefined) {
+    throw new Error("Valid CSS selectors cannot begin with a number")
+  }
+
   if ((classes && type === "string") || type === "number") {
     return classes
   }

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -71,3 +71,9 @@ test("not owned props", () => {
 
   delete Object.prototype.myFunction
 })
+
+test("can't start with number", () => {
+  expect(() => {
+    cw(1)
+  }).toThrow()
+})


### PR DESCRIPTION
This PR fixes issue #8.

Since you're using `wrap` recursively, we can throw an error when `type` is a `Number` and no `prefix` is defined.